### PR TITLE
Fix obsolete patch declaration for jzip

### DIFF
--- a/jzip.rb
+++ b/jzip.rb
@@ -6,9 +6,7 @@ class Jzip < Formula
   sha256 '722a81ee1a9cff51f468dbf38c54a2b149e6cda71e6c540caf4ec4308e290d9d'
   version '2.1'
 
-  def patches
-    :DATA
-  end
+  patch :DATA
 
   def install
     ENV.delete("SDKROOT")


### PR DESCRIPTION
This fixes this error message from Homebrew:

```
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/wjwwood/homebrew-zork/jzip.rb
jzip: Calling a Formula#patches definition is disabled! Use 'patch do' block calls instead.
Please report this issue to the wjwwood/zork tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/wjwwood/homebrew-zork/jzip.rb:9
```